### PR TITLE
Remove dead EmailJS fallback credentials from contact form

### DIFF
--- a/src/Hooks/useEmail.ts
+++ b/src/Hooks/useEmail.ts
@@ -10,17 +10,15 @@ const useEmailJs = () => {
 
     try {
       // Using explicit references so CRA inlines them at build time.
-      // Falls back to the known-working EmailJS credentials so the form keeps
-      // working even when REACT_APP_EMAILJS_* env vars aren't configured on
-      // the deployment platform.
-      const serviceId = process.env.REACT_APP_EMAILJS_SERVICE_ID || "service_j3v6wo8";
-      const templateId = process.env.REACT_APP_EMAILJS_TEMPLATE_ID || "template_yh66j2a";
+      const serviceId = process.env.REACT_APP_EMAILJS_SERVICE_ID;
+      const templateId = process.env.REACT_APP_EMAILJS_TEMPLATE_ID;
       // EmailJS renamed "user_id" to "public key"; support both env names.
-      const userId =
-        process.env.REACT_APP_EMAILJS_USER_ID ||
-        process.env.REACT_APP_EMAILJS_PUBLIC_KEY ||
-        "7mArU2PI2PH2T6cun";
+      const userId = process.env.REACT_APP_EMAILJS_USER_ID || process.env.REACT_APP_EMAILJS_PUBLIC_KEY;
       const privateKey = process.env.REACT_APP_EMAILJS_PRIVATE_KEY;
+
+      if (!serviceId || !templateId || !userId) {
+        throw new Error("EmailJS environment variables are missing.");
+      }
 
       formData.append("service_id", serviceId);
       formData.append("template_id", templateId);


### PR DESCRIPTION
## Summary
- The contact form's previously-restored fallback EmailJS credentials (`service_j3v6wo8` / `template_yh66j2a` / public key `7mArU2PI2PH2T6cun`) now return **"Account not found"** from EmailJS — confirmed by a live failure screenshot on the deployed preview.
- Reverts `src/Hooks/useEmail.ts` to require `REACT_APP_EMAILJS_SERVICE_ID`, `REACT_APP_EMAILJS_TEMPLATE_ID`, and `REACT_APP_EMAILJS_USER_ID`/`REACT_APP_EMAILJS_PUBLIC_KEY` as env vars, throwing a clear "EmailJS environment variables are missing" error instead of silently using a dead credential.

## Why
Silently falling back to a guaranteed-broken key just hides the real problem behind a confusing "Account not found" alert. The fix on the code side is done; **the contact form will not work until valid EmailJS env vars are set on the deployment platform(s)** (Vercel/Netlify/Firebase) — see PR comment for what to set.

## Test plan
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `CI=false npm run build` compiles successfully
- [ ] Set `REACT_APP_EMAILJS_SERVICE_ID`, `REACT_APP_EMAILJS_TEMPLATE_ID`, `REACT_APP_EMAILJS_PUBLIC_KEY` on the deployment platform(s) from your current EmailJS dashboard, then test the live contact form


---
_Generated by [Claude Code](https://claude.ai/code/session_01WMvBeQZzjJct4m4BpEzefC)_